### PR TITLE
GitHub Sponsoring

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -47,6 +47,9 @@ Der **open\HSR** hat sich zum Ziel gesetzt, diese Events zu unterstützen.
 ### [Git/Github Workshop](https://github.com/openhsr/git-github-workshop/)
 > In diesem vom open\HSR organisierten Workshop werden die ersten Hürden beim Arbeiten mit Git und GitHub überwunden. Wir wollen dir die Hemmschwelle nehmen, damit du unbeschwert zu Open Source und open\HSR Projekten beitragen kannst.
 
+Dieser Workshop wird von GitHub mit Handouts & Swag unterstützt :tada: :heart: :octocat:
+
+
 ### [Swiss Python Summit](http://www.python-summit.ch/)
 
 > This summit is all about the programming language you love! Discover the wide field of Python applications, hear how others use the snake and meet Swiss Pythonistas. The conference is suited for all skill levels, from early beginners to expert developers.

--- a/pages/community.md
+++ b/pages/community.md
@@ -44,10 +44,12 @@ Ein grosser Teil unserer Kommunikation und Arbeit findet auf Github statt. Falls
 An der HSR finden verschiedene regelmässige und einige weniger regelmässige **Events zu Open Source-Themen** statt.
 Der **open\HSR** hat sich zum Ziel gesetzt, diese Events zu unterstützen.
 
+<img src="/assets/emoji/octocat.png" style="float: right; box-shadow: none;" />
 ### [Git/Github Workshop](https://github.com/openhsr/git-github-workshop/)
+
 > In diesem vom open\HSR organisierten Workshop werden die ersten Hürden beim Arbeiten mit Git und GitHub überwunden. Wir wollen dir die Hemmschwelle nehmen, damit du unbeschwert zu Open Source und open\HSR Projekten beitragen kannst.
 
-Dieser Workshop wird von GitHub mit Handouts & Swag unterstützt :tada: :heart: :octocat:
+Dieser Workshop wird von [GitHub](https://github.com/) mit Handouts & Swag unterstützt :tada: :heart: :octocat:
 
 
 ### [Swiss Python Summit](http://www.python-summit.ch/)


### PR DESCRIPTION
Habe soeben die Zusage von GitHub bekommen, dass sie uns mit Swag und Handouts unterstützen.
Die Unterlagen wurden heute versandt - adressiert an die HSR - z.H. S. Keller.

Da GitHub damit ein offizieller Sponsor ist, gehört die entsprechende Info auch auf die Website

>You may list us as a sponsor by using the GitHub logo on any printed or online advertising

Darum habe ich unter dem Workshop eine explizite Zeile hinzugefügt. Im Workshop-Repository ist dies bereits erfolgt.