### PR TITLE
use AptUrlRedirector instead of plain apt:// URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ Um an der Webseite mitarbeiten zu können, benötigst du einen [Github Account](
 
 1. **Benötigte Abhängigkeiten installieren**<br>
    Bevor du loslegen kannst, musst du [Git](https://git-scm.com/), Make und [Docker](https://docs.docker.com/engine/installation/) installieren: <br>
-   [Git Jetzt installieren](apt://git)
-   [Make Jetzt installieren](apt://make)
-   [Docker Jetzt installieren](apt://docker)
+   [Git Jetzt installieren](http://apt.ubuntu.com/p/git)
+   [Make Jetzt installieren](http://apt.ubuntu.com/p/make)
+   [Docker Jetzt installieren](http://apt.ubuntu.com/p/docker)
 2. **Forke das Projekt auf Github**<br>
    Gehe dazu mit dem Webbrowser auf das [Repository www.openhsr.ch](https://github.com/openhsr/www.openhsr.ch) und klicke auf `Fork`:<br>
    ![Screenshot zum Forken eines Projekts](/assets/contribute/projekt_einrichten_1.png)

--- a/_app/backintime.md
+++ b/_app/backintime.md
@@ -17,7 +17,7 @@ Da Back In Time einige Vorteile bietet, empfehlen wir Back In Time.
 ## Installation
 1. **Benötigte Abhängigkeiten installieren**<br>
    Bevor du loslegen kannst, musst du das Paket ``backintime-gnome`` installieren.
-   [Jetzt installieren](apt://backintime-gnome)
+   [Jetzt installieren](http://apt.ubuntu.com/p/backintime-gnome)
 {% toggle %}
 
 

--- a/_hsr/vpn.md
+++ b/_hsr/vpn.md
@@ -19,7 +19,7 @@ Hinweis: Richte das VPN nicht im HSR-Secure-WLAN ein - aus dem HSR-Netz können 
 
 1. **Benötigte Abhängigkeiten installieren**<br>
    Bevor du loslegen kannst, musst du noch das Paket ``network-manager-vpnc-gnome`` installieren.
-   [Jetzt installieren](apt://network-manager-vpnc-gnome)
+   [Jetzt installieren](http://apt.ubuntu.com/p/network-manager-vpnc-gnome)
 2. **Öffne die Netzwerkeinstellungen** über den Netzwerkindikatoren am oberen linken Bildschirmrand via ```VPN-Verbindungen``` + ```VPN konfigurieren...```<br>
    {% lightbox /assets/hsr/vpn/vpn_networkmanager_1.png --data="vpn ubuntu" --title="Netzwerkeinstellungen über den Netzwerkindikatoren" --alt="Netzwerkeinstellungen über den Netzwerkindikatoren" %}
 3. Klick auf den Button **Hinzufügen**<br>

--- a/css/main.scss
+++ b/css/main.scss
@@ -194,7 +194,7 @@ blockquote {
 }
 
 /** APT BUTTONS */
-a[href^="apt://"] {
+a[href^="http://apt.ubuntu.com/p/"] {
   display: block;
 	background: #2196F3;
 	border: 1px solid #0D47A1;
@@ -209,13 +209,13 @@ a[href^="apt://"] {
   transition: all 0.2s ease;
 }
 
-a[href^="apt://"]::before {
+a[href^="http://apt.ubuntu.com/p/"]::before {
   font-family: "FontAwesome";
   content: "\f019";
   padding: 0.5rem;
 }
 
-a[href^="apt://"]:hover {
+a[href^="http://apt.ubuntu.com/p/"]:hover {
   background:#1976D2;
   box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.5);
 }


### PR DESCRIPTION
`README.md` isn't displayed on the Jekyll-generated website (or if it is, I'm not aware where), so the primary way to view it is on the GitHub repository's page. GitHub MarkDown doesn't support links with `apt://` URLs. Thus, use redirection HTTP URLs provided by Ubuntu as documented on [the Ubuntu wiki article "AptUrlRedirector"](https://wiki.ubuntu.com/AptUrlRedirector)