### PR TITLE
Piwik entfernen

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,4 +39,3 @@
 <script src="/assets/jquery/jquery-2.2.2.min.js"></script>
 <script src="/assets/lightbox/js/lightbox.min.js"></script>
 <script src="/js/script.js"></script>
-<noscript><p><img src="//piwik.fh2.ch/piwik.php?idsite=8" style="border:0;" alt="" /></p></noscript>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,18 +14,4 @@
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
 
   <link href='/assets/fonts/fonts.css' rel='stylesheet' type='text/css'>
-  <!-- Piwik -->
-  <script type="text/javascript">
-    var _paq = _paq || [];
-    _paq.push(["setDomains", ["*.www.openhsr.ch"]]);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="//piwik.fh2.ch/";
-      _paq.push(['setTrackerUrl', u+'piwik.php']);
-      _paq.push(['setSiteId', 8]);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
 </head>


### PR DESCRIPTION
Da der neue Vorstand keinen Zugriff auf die Piwik Instanz hat, würde ich dies vorerst entfernen.