### PR TITLE
Bundler Permission Problem behoben

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
 script:
   - mkdir _site/
   - chmod 777 _site/
+  - chmod a+rwx -R $PWD
   - make buildimage build
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 script:
   - mkdir _site/
   - chmod 777 _site/
-  - chmod a+rwx -R $PWD
+  - sudo chown 1000 -R $PWD
   - make buildimage build
 
 deploy:


### PR DESCRIPTION
Moment funktioniert der Travis-Build nicht. Beim Ausführen von `bundle install` wird auf `src/vendor/bundle` zugegriffen, dieser Folder ist aber nicht beschreibbar:

`
Bundler::PermissionError: There was an error while trying to write to
'/src/vendor/bundle/cache'. It is likely that you need to grant write
permissions for that path.
`

Dieser PR übernimmt eine mögliche Lösung, die ich [hier](https://stackoverflow.com/questions/34031397/running-docker-on-ubuntu-mounted-host-volume-is-not-writable-from-container) finden konnte. Vielleicht hat sonst noch Jemand eine Idee, wie man das Problem schöner lösen könnte.