### PR TITLE
Add Evolution as Outlook Aternative

### DIFF
--- a/pages/app.md
+++ b/pages/app.md
@@ -8,7 +8,7 @@ Darum haben wir dir hier Alternativen aufgelistet.
 ## Übersicht
 Programm        | Empfohlene Alternative            |       Weitere Alternativen
 ----------------|-----------------------------------|----------------------------
-Outlook         | [Thunderbird](/app/thunderbird)   | Mac Mail, Claws-Mail
+Outlook         | [Thunderbird](/app/thunderbird)   | [Evolution](https://wiki.gnome.org/Apps/Evolution/), Mac Mail, Claws-Mail
 HSR Mapper      | [open\HSR Connect](https://github.com/openhsr/connect) | [Kommandozeilen-Scripts](https://gist.github.com/raphiz/29dd1ed3145b06b9398d)
 [DASYLab](/tipps/dasylab) (Modul ICTh)			| keine / Verwendung mit [Wine](/tipps/wine) 	| -
 


### PR DESCRIPTION
(Gnome) Evolution ist meiner Meinung nach eine ziemlich passable Alternative zu Outlook. Mit dem Einrichtungsassistenten funktionieren E-Mail, Kalender, TODO und Adressbuch ohne Probleme.