### PR TITLE
fix: updated main Pages to OST

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ layout: page
 permalink: /contribute/
 ---
 
-# Webseite [www.openhsr.ch](https://www.openhsr.ch/)
+# Webseite [www.openost.ch](https://www.openost.ch/)
 
 ## Wie kann ich mithelfen?
 Erst einmal: Wir freuen uns über DEINE Mithilfe :thumbsup::tada:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,7 +27,7 @@
 	</section>
 	<section class="legal">
 		<p>
-			<strong>&copy; open\HSR, <time datetime="{{site.time | date: "%Y-%m-%d" }}">{{site.time | date: "%d.%m.%Y" }}</time></strong>.
+			<strong>&copy; open\OST, <time datetime="{{site.time | date: "%Y-%m-%d" }}">{{site.time | date: "%d.%m.%Y" }}</time></strong>.
 			Der Inhalt ist unter der <a href="https://www.gnu.org/copyleft/fdl.html" rel="license">GNU Free Documentation License</a> verfügbar, sofern nicht anders angegeben.
 		</p>
 	</section>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="author" content="open\HSR">
+  <meta name="author" content="open\OST">
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>

--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -1,5 +1,5 @@
 <section id="slider">
-  <h1>open\HSR</h1>
-  <h2>Aus alt.comp.hsr wird <strong>open\HSR</strong>!</h2>
+  <h1>open\OST</h1>
+  <h2>Aus open\HSR wird <strong>open\OST</strong>!</h2>
   <a href="/community/" class="button">Jetzt Mitglied werden</a>
 </section>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -9,14 +9,14 @@ layout: default
   <main role="main">
     <section id="front">
       <h1>{{ page.title }}</h1>
-      <p>Wir fördern die <strong>Open Source Community</strong> und unterstützen dich bei der Benutzung deines <strong>alternativen Betriebssystems</strong> an der HSR.</p>
+      <p>Wir fördern die <strong>Open Source Community</strong> und unterstützen dich bei der Benutzung deines <strong>alternativen Betriebssystems</strong> an der OST.</p>
 
       {{ content }}
 
       <div>
         <article>
           <i class="fa fa-rocket"></i>
-          <h2>Arbeiten an der HSR</h2>
+          <h2>Arbeiten an der OST</h2>
 	  <p>Alles für einen gelungenen Studienstart</p>
           <a href="/hsr/" class="button">Überlebensguide</a>
         </article>
@@ -24,7 +24,7 @@ layout: default
         <article>
           <i class="fa fa-users"></i>
           <h2>Community</h2>
-          <p>Open Source, open\HSR und Events</p>
+          <p>Open Source, open\OST und Events</p>
           <a href="/community/" class="button">Be a part of it!</a>
         </article>
 
@@ -38,7 +38,7 @@ layout: default
         <article>
           <i class="fa fa-question-circle"></i>
           <h2>Fragen &amp; Antworten</h2>
-	  <p>Fragen zu Linux oder macOS an der HSR? </p>
+	  <p>Fragen zu Linux oder macOS an der OST? </p>
           <a href="/hilfe/" class="button">Wir helfen dir.</a>
         </article>
 

--- a/pages/app.md
+++ b/pages/app.md
@@ -2,7 +2,7 @@
 title: Programme
 ---
 
-Leider sind nicht alle Programme, die an der HSR eingesetzt werden, auf Linux & Co verfügbar.
+Leider sind nicht alle Programme, die an der OST eingesetzt werden, auf Linux & Co verfügbar.
 Darum haben wir dir hier Alternativen aufgelistet.
 
 ## Übersicht

--- a/pages/community.md
+++ b/pages/community.md
@@ -9,20 +9,20 @@ redirect_from:
 
 ## Werde Mitglied!
 
-Du möchtest **Open Source an der HSR** fördern oder ein nicht offiziell unterstützes Betriebssystem an der HSR nutzen?
+Du möchtest **Open Source an der OST** fördern oder ein nicht offiziell unterstützes Betriebssystem an der OST nutzen?
 Dann bist du bei uns richtig.
 
 Mit deiner Mitgliedschaft ...
 
-* wirst du Teil der lebendigen Community rund um Open Source-Projekte an der HSR
+* wirst du Teil der lebendigen Community rund um Open Source-Projekte an der OST
 * setzt du ein Zeichen für freie Software
-* förderst du unser Engagement für die Unterstützung von alternativen Betriebssystemen wie Linux und macOS an der HSR
-* bekommst du einen open\HSR Sticker für dein Notebook!
+* förderst du unser Engagement für die Unterstützung von alternativen Betriebssystemen wie Linux und macOS an der OST
+* bekommst du einen open\OST Sticker für dein Notebook!
 * wirst du von Zeit zu Zeit mit einem kurzen, prägnanten Newsletter über aktuelle Veranstaltungen und Projekte informiert (kann natürlich abbestellt werden :wink:)
 
 Die **Mitgliedschaft ist kostenlos und unverbindlich**. Du darfst mithelfen, wie es dir nach Zeit und Laune passt!
 
-<a href="mailto:info@openhsr.ch?subject=Mitglied%20werden&body=Hallo%20Zusammen!%0A%0AIch%20w%C3%BCrde%20gerne%20Mitglied%20im%20open%5CHSR%20werden!%0A%0AMein%20Github%20Benutzername%20lautet%20%5BGITHUB%20Benutzername%5D.%0A%5BFalls%20du%20keinen%20Github%20Account%20hast%2C%20kannst%20du%20diesen%20Absatz%20l%C3%B6schen%5D%0A%0ALiebe%20Gr%C3%BCsse%2C%0A%5BNAME%5D" class="button">Jetzt Mitglied werden!</a>
+<a href="mailto:info@openhsr.ch?subject=Mitglied%20werden&body=Hallo%20Zusammen!%0A%0AIch%20w%C3%BCrde%20gerne%20Mitglied%20im%20open%5COST%20werden!%0A%0AMein%20Github%20Benutzername%20lautet%20%5BGITHUB%20Benutzername%5D.%0A%5BFalls%20du%20keinen%20Github%20Account%20hast%2C%20kannst%20du%20diesen%20Absatz%20l%C3%B6schen%5D%0A%0ALiebe%20Gr%C3%BCsse%2C%0A%5BNAME%5D" class="button">Jetzt Mitglied werden!</a>
 
 ## Treffpunkt
 **Community** - das ist das Herzstück von Open Source. Und damit auch von unserem Verein! Sei es, um Fragen zu macOS und Linux zu klären, an unseren Open Source Projekten mitzuhelfen - oder einfach Teil der Community zu sein: Du bist willkommen!
@@ -33,7 +33,7 @@ Leider findet der Treffpunkt derzeit nicht regelmässig statt. Solltest du Inter
 
 ## Mithelfen
 
-Wir sammeln Ideen für Veranstaltungen, Events, Flyer etc. und verwirklichen diese in kleineren Gruppen. Damit ist der Aufwand für die Mitglieder abschätzbar und zeitlich begrenzt - wir wollen schliesslich keine Last fürs Studium sein. Wo wir deine Unterstützung brauchen, z.B. wenn die Untervereine der HSR vorgestellt werden, erfährst du über den Newsletter. Natürlich kannst du auch eigene Ideen mit einbringen!
+Wir sammeln Ideen für Veranstaltungen, Events, Flyer etc. und verwirklichen diese in kleineren Gruppen. Damit ist der Aufwand für die Mitglieder abschätzbar und zeitlich begrenzt - wir wollen schliesslich keine Last fürs Studium sein. Wo wir deine Unterstützung brauchen, z.B. wenn die Untervereine der OST vorgestellt werden, erfährst du über den Newsletter. Natürlich kannst du auch eigene Ideen mit einbringen!
 
 Du kannst konkret an Projekten wie der [Website](https://github.com/openhsr/www.openhsr.ch/issues) oder dem [open\HSR-Connect](https://github.com/openhsr/connect/issues) mitarbeiten, in dem du eines aus vielen Tickets, mit dem Label `help wanted`, auf GitHub in Angriff nimmst. Unklarheiten ungehemmt ins Ticket schreiben.
 
@@ -43,15 +43,15 @@ Ein grosser Teil unserer Kommunikation und Arbeit findet auf GitHub statt. Falls
 
 ## Verein
 
-{% lightbox /assets/logo.png --data="logo" --title="Logo open\HSR" --alt="Logo open\HSR" --class="no-shadow" %}
+{% lightbox /assets/logo.png --data="logo" --title="Logo open\OST" --alt="Logo open\OST" --class="no-shadow" %}
 
 ### Unsere Ziele
 
-1. Förderung der **Open Source-Kultur** und von **Open Source-Projekten** an der HSR
-2. Interessensvertretung an der HSR für die **Unterstützung alternativer Betriebssysteme**
-3. **Unterstützung von Einsteigern** in der Nutzung von Open Source-Software im Hinblick auf das Studium an der HSR
+1. Förderung der **Open Source-Kultur** und von **Open Source-Projekten** an der OST
+2. Interessensvertretung an der OST für die **Unterstützung alternativer Betriebssysteme**
+3. **Unterstützung von Einsteigern** in der Nutzung von Open Source-Software im Hinblick auf das Studium an der OST
 
-Der **open\HSR** ist ein Unterverein des [VSHSR](https://www.vshsr.ch/) (Verein der Studierenden an der HSR).
+Der **open\OST** ist ein Unterverein des [VSHSR](https://www.vshsr.ch/) (Verein der Studierenden an der OST).
 Als solcher unterstützt er auch die Ziele und Ideale des VSHSR.
 
 
@@ -59,9 +59,9 @@ Als solcher unterstützt er auch die Ziele und Ideale des VSHSR.
 
 Um diese Ziele zu erreichen,
 
-1. unterstützt der Verein **Open Source-Events** und **verknüpft die Open Source-Interessierten** an der HSR.
+1. unterstützt der Verein **Open Source-Events** und **verknüpft die Open Source-Interessierten** an der OST.
 2. bietet der Verein eine Sammlung von **Anleitungen und Empfehlungen** für alternative Betriebssysteme (Linux/macOS) und Software.
-   Diese werden jeweils auf die an der HSR relevanten Inhalte eingeschränkt, führen aber nach Möglichkeit weiterführende Quellen auf.
+   Diese werden jeweils auf die an der OST relevanten Inhalte eingeschränkt, führen aber nach Möglichkeit weiterführende Quellen auf.
 3. betreibt und unterhält der Verein geeignete Plattformen (z.B. ein E-Mail-Postfach), auf dem **Hilfe bei Fragen** angeboten wird.
 
 
@@ -85,14 +85,14 @@ Pull Requests für die Statuten werden an der nächsten GV als Änderungsantrag 
 
 ### Kontakt
 
-Falls du dich für den **open\HSR** interessierst, freuen wir uns immer über ein E-Mail unter <info@openhsr.ch>.
+Falls du dich für den **open\OST** interessierst, freuen wir uns immer über ein E-Mail unter <info@openhsr.ch>.
 
 ### Sponsoring & Kontoinformationen
 
-Möchtest du unseren Verein finanziell unterstützen und Sponsor werden? Sponsoren haben die Möglichkeit, ihr Logo im open\HSR Flyer, auf unserer Webseite und an open\HSR Anlässen zu platzieren. Für weitere Informationen steht der Vorstand gerne unter <info@openhsr.ch> zur Verfügung.
+Möchtest du unseren Verein finanziell unterstützen und Sponsor werden? Sponsoren haben die Möglichkeit, ihr Logo im open\OST Flyer, auf unserer Webseite und an open\OST Anlässen zu platzieren. Für weitere Informationen steht der Vorstand gerne unter <info@openhsr.ch> zur Verfügung.
 
 ```
-open\HSR
+open\OST
 IBAN CH13 0078 1621 1985 7200 0
 St. Galler Kantonalbank
 St. Leonhardstrasse 25

--- a/pages/events.md
+++ b/pages/events.md
@@ -1,8 +1,8 @@
 ---
 title: Events
 ---
-An der HSR finden verschiedene regelmässige und einige weniger regelmässige **Events zu Open Source-Themen** statt.
-Der **open\HSR** hat sich zum Ziel gesetzt, diese Events zu unterstützen.
+An der OST finden verschiedene regelmässige und einige weniger regelmässige **Events zu Open Source-Themen** statt.
+Der **open\OST** hat sich zum Ziel gesetzt, diese Events zu unterstützen.
 
 {% for event_page in site.events %}
 
@@ -20,7 +20,7 @@ Mehr zu [{{ event_page.title }}]({{ event_page.url }})</a></p>
 <img src="/assets/emoji/octocat.png" style="float: right; box-shadow: none;" />
 # [Git/GitHub Workshop](https://github.com/openhsr/git-github-workshop/)
 
-> In diesem vom open\HSR organisierten Workshop werden die ersten Hürden beim Arbeiten mit Git und GitHub überwunden. Wir wollen dir die Hemmschwelle nehmen, damit du unbeschwert zu Open Source und open\HSR Projekten beitragen kannst.
+> In diesem vom open\OST organisierten Workshop werden die ersten Hürden beim Arbeiten mit Git und GitHub überwunden. Wir wollen dir die Hemmschwelle nehmen, damit du unbeschwert zu Open Source und open\OST Projekten beitragen kannst.
 
 Dieser Workshop wird von [GitHub](https://github.com/) mit Handouts & Swag unterstützt :tada: :heart: :octocat:
 

--- a/pages/hilfe.md
+++ b/pages/hilfe.md
@@ -4,7 +4,7 @@ parent: community
 hidden_from_navigation: true
 ---
 
-Du hast Fragen zu deinem Linux, macOS oder generell Open Source an der HSR? Wir helfen dir.
+Du hast Fragen zu deinem Linux, macOS oder generell Open Source an der OST? Wir helfen dir.
 
 ## Programme und Dokumentationen
 

--- a/pages/hsr.md
+++ b/pages/hsr.md
@@ -4,27 +4,25 @@ title: Dokumentationen
 
 ## Überlebensguide
 
-Der Überlebensguide hilft dir beim Start mit deinem Linux oder Mac an der HSR.
+Der Überlebensguide hilft dir beim Start mit deinem Linux oder Mac an der OST.
 
-Weitere Anleitungen findest du auch auf unserer Webseite unter <https://www.openhsr.ch/>. Falls du weitere Hilfe mit deinem Linux oder Mac benötigst, findest du unter [Hilfe](/hilfe/), wie du uns kontaktieren kannst.
+Weitere Anleitungen findest du auch auf unserer Webseite unter <https://www.openost.ch/>. Falls du weitere Hilfe mit deinem Linux oder Mac benötigst, findest du unter [Hilfe](/hilfe/), wie du uns kontaktieren kannst.
 
-Für Mac gibt es auch gute Anleitungen vom ITA im *[HSR-Intranet](https://intranet.hsr.ch)* → *IT-Informatikdienste* → *Support / IT-ServiceDesk* → *Einstieg für Erstsemestrige*.
+Für Mac gibt es auch gute Anleitungen vom ITA im *[OST-Intranet](https://intranet.hsr.ch)* → *IT-Informatikdienste* → *Support / IT-ServiceDesk* → *Einstieg für Erstsemestrige*.
 
-##  :closed\_lock\_with\_key: HSR-Login
+##  :closed\_lock\_with\_key: OST-Login
 
-Das HSR-Login ist dein persönliches Login, welches du zum Studienstart erhalten hast.  
-In unseren Dokumentationen verwenden wir jeweils den Benutzernamen ```mmuster``` mit dem Passwort ```GeHeim007```
-
-Wenn du dein Passwort noch nicht geändert hast, solltest du dies über das [HSR-Webmail](https://webmail.hsr.ch/) machen.
+Das OST-Login ist dein persönliches Login, welches du zum Studienstart erhalten hast.  
+In unseren Dokumentationen verwenden wir jeweils den Benutzernamen ```maria.muster``` mit dem Passwort ```GeHeim007```
 
 ## :signal_strength: WLAN
 
-Überall an der HSR hast du Zugriff auf das ```HSR-Secure```-Netzwerk.  
+Überall an der OST hast du Zugriff auf das ```eduroam```-Netzwerk.  
 Alle Angaben zum Einrichten findest du unter [Dokumentationen → WLAN](/hsr/wlan/).
 
 ## :envelope: E-Mail
 
-An der HSR erhälst du eine persönliche E-Mail-Adresse in der Form ```vorname.nachname@hsr.ch``` bzw. ```vnachname@hsr.ch```. Diese Adresse ist nur während der Zeit an der HSR für dich reserviert.
+An der OST erhälst du eine persönliche E-Mail-Adresse in der Form ```vorname.nachname@ost.ch```. Diese Adresse ist nur während der Zeit an der OST für dich reserviert.
 
 Wie du dein E-Mail-Programm (zum Beispiel [Thunderbird](/app/thunderbird/)) einrichtest, findest du unter [Dokumentationen → E-Mail](/hsr/email/).
 
@@ -41,14 +39,14 @@ Es gibt zwei Möglichkeiten zum Drucken:
 ### E-Mail mit PDF im Anhang
 
 Dies ist die einfachste Lösung, ohne dass du Treiber auf deinem Computer installieren musst.  
-Sende einfach ein E-Mail mit einem PDF im Anhang an ```mobileprint@hsr.ch```. Du kannst das Dokument danach mit deinem Badge an jedem Drucker der HSR abrufen.
+Sende einfach ein E-Mail mit einem PDF im Anhang an ```mobileprint@hsr.ch```. Du kannst das Dokument danach mit deinem Badge an jedem Drucker der OST abrufen.
 
 ### Drucker einrichten
 
-Aktuell müssen Drucker auf dem Mac und Linux einzeln von Hand installiert und konfiguriert werden, es gibt leider (noch) kein Pendant zum HSR-Mapper.
+Aktuell müssen Drucker auf dem Mac und Linux einzeln von Hand installiert und konfiguriert werden, es gibt leider (noch) kein Pendant zum OST-Mapper.
 
 ## :school: VPN
 
-Um von extern auf die Dateiablagen der HSR zuzugreifen, brauchst du eine VPN-Verbindung. Wie du diese einrichtest, findest du unter [Dokumentationen → VPN](/hsr/vpn).
+Um von extern auf die Dateiablagen der OST zuzugreifen, brauchst du eine VPN-Verbindung. Wie du diese einrichtest, findest du unter [Dokumentationen → VPN](/hsr/vpn).
 
 Übrigens: Eine VPN-Verbindung ist kostenlos über Hotspots von [Swisscom](http://hotspotlocator.swisscom.ch/en/locator), [Monzoon](http://hotspot.monzoon.net/?sec=hot&cot=hsl&lang=en) und [TheNet](https://wlan.thenet.ch/en/hotspot_locator) möglich.

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,6 +1,6 @@
 ---
 layout: index
-title: Willkommen beim open\HSR!
+title: Willkommen beim open\OST!
 hidden_from_navigation: true
 permalink: /
 ---

--- a/pages/sponsoring.md
+++ b/pages/sponsoring.md
@@ -4,11 +4,11 @@ hidden_from_navigation: true
 parent: community
 ---
 
-Dieses Dokument gibt eine Übersicht über das Sponsoring im open\HSR.
+Dieses Dokument gibt eine Übersicht über das Sponsoring im open\OST.
 
 ## Einführung
 
-Um für alle interessierten Personen offen zu sein (unabhängig der finanziellen Mittel), erhebt der open\HSR keine Mitgliedergebühren.
+Um für alle interessierten Personen offen zu sein (unabhängig der finanziellen Mittel), erhebt der open\OST keine Mitgliedergebühren.
 Zur Finanzierung setzt der Verein ausschliesslich auf Sponsoring.
 
 Der Verwendungszweck der eingenommen Mittel wird von der Generalversammlung definiert.
@@ -16,16 +16,16 @@ In den vergangenen Jahren wurden jeweils folgende Aktivitäten durchgeführt:
 
 
 - Durchführung von Anlässen (z.B. [Git-GitHub-Workshop](https://github.com/openhsr/git-github-workshop), Hackatons) 
-- Betrieb und Unterhalt des [open\HSR Studentenportals](https://studentenportal.ch/)
-- Betrieb und Unterhalt der [open\HSR-Webseite](https://www.openhsr.ch/), welche Dokumentationen im Bereich alternative Betriebssysteme und Open Source an der HSR beinhalten.
+- Betrieb und Unterhalt des [open\OST Studentenportals](https://studentenportal.ch/)
+- Betrieb und Unterhalt der [open\OST-Webseite](https://www.openost.ch/), welche Dokumentationen im Bereich alternative Betriebssysteme und Open Source an der OST beinhalten.
 - Durchführung von Vereinsanlässen (z.B. GV, Mitgliedertreffen)
 
 Der Verein ist für Intiativen seitens der Mitglieder offen und kann diese finanziell unterstützen, sofern sie sich mit dem Vereinsziel decken.
 
 ## Potential für Sponsoren
 
-Der open\HSR bietet Sponsoren die Möglichkeit, ihr Logo (und, bei digitalen Medien, Link zur Website) an verschiedenen Orten im Zusammenhang mit Open Source zu präsentieren.
-In erster Linie werden damit aktuelle Studierende und Alumni der HSR angesprochen, welche an dem Sponsor interessiert sein könnten (z.B. als Arbeitsgeber oder Dienstleister).
+Der open\OST bietet Sponsoren die Möglichkeit, ihr Logo (und, bei digitalen Medien, Link zur Website) an verschiedenen Orten im Zusammenhang mit Open Source zu präsentieren.
+In erster Linie werden damit aktuelle Studierende und Alumni der OST angesprochen, welche an dem Sponsor interessiert sein könnten (z.B. als Arbeitsgeber oder Dienstleister).
 
 
 ## Konditionen
@@ -42,18 +42,18 @@ Die Einstufung wird nach geschätzter Zielgruppengrösse und Streuung gemacht.
 
 **Zielgruppen:**
 
-- Sämtliche Studierenden der HSR (ca. 1500 Personen)
+- Sämtliche Studierenden der OST (ca. 1500 Personen)
 - Nutzer [studentenportal.ch](https://studentenportal.ch) (ca. 100'000 Seitenaufrufe/Jahr)
-- open\HSR-Mitglieder
-- Benutzer von OpenSource-Software und alternativen Betriebssystemen an der HSR (in erster Linie Linux und macOS)
+- open\OST-Mitglieder
+- Benutzer von OpenSource-Software und alternativen Betriebssystemen an der OST (in erster Linie Linux und macOS)
 
 **Leistungen**:
 
-- 1 Logo auf open\HSR-Flyer (ca. Briefmarkengross)  
-  Der open\HSR Flyer wird an sämtliche neu eintretenden HSR-Studierende verteilt.
-- 1 Logo auf der open\HSR-Website
-- 1 Logo auf der Startseite des HSR Studentenportals
-- Aufhängen von 1 Logo an open\HSR-Events (A4-Format)
+- 1 Logo auf open\OST-Flyer (ca. Briefmarkengross)  
+  Der open\OST Flyer wird an sämtliche neu eintretenden OST-Studierende verteilt.
+- 1 Logo auf der open\OST-Website
+- 1 Logo auf der Startseite des OST Studentenportals
+- Aufhängen von 1 Logo an open\OST-Events (A4-Format)
 
 
 ### Sponsoren
@@ -63,13 +63,13 @@ Die Einstufung wird nach geschätzter Zielgruppengrösse und Streuung gemacht.
 **Zielgruppen:**
 
 - Nutzer [studentenportal.ch](https://studentenportal.ch) (ca. 100'000 Seitenaufrufe/Jahr)
-- open\HSR-Mitglieder
-- Benutzer von OpenSource-Software und alternativen Betriebssystemen an der HSR (in erster Linie Linux und macOS)
+- open\OST-Mitglieder
+- Benutzer von OpenSource-Software und alternativen Betriebssystemen an der OST (in erster Linie Linux und macOS)
 
 **Leistungen:**
 
-- 1 Logo auf der open\HSR-Website
-- 1 Logo auf der Startseite des HSR Studentenportals
+- 1 Logo auf der open\OST-Website
+- 1 Logo auf der Startseite des OST Studentenportals
 
 ### Supporter
 
@@ -77,12 +77,12 @@ Die Einstufung wird nach geschätzter Zielgruppengrösse und Streuung gemacht.
 
 **Zielgruppen:**
 
-- open\HSR-Mitglieder
-- Benutzer von OpenSource-Software und alternativen Betriebssystemen an der HSR (in erster Linie Linux und macOS)
+- open\OST-Mitglieder
+- Benutzer von OpenSource-Software und alternativen Betriebssystemen an der OST (in erster Linie Linux und macOS)
 
 **Leistungen**: 
 
-- 1 Logo auf der open\HSR-Website
+- 1 Logo auf der open\OST-Website
 
 ## Interessiert?
 

--- a/pages/styleguide.md
+++ b/pages/styleguide.md
@@ -9,7 +9,7 @@ Unser Grundsatz: Kurz und knackig, aber nichts verheimlichen. *Users first*!
 
 ## Beispiele / Konfigurationen
 
-Es war einmal eine Studentin, die hiess ```Maria Muster```. Maria war während <del>dem Studium</del> den Vorlesungen fleissig und hat viele Dokumentationen mit dem Benutzernamen ```mmuster```, der E-Mail-Adresse ```maria.muster@hsr.ch``` und Marias Passwort, ```GeHeim007```, erstellt.
+Es war einmal eine Studentin, die hiess ```Maria Muster```. Maria war während <del>dem Studium</del> den Vorlesungen fleissig und hat viele Dokumentationen mit dem Benutzernamen ```maria.muster```, der E-Mail-Adresse ```maria.muster@ost.ch``` und Marias Passwort, ```GeHeim007```, erstellt.
 
 ### Shell
 Auf ihrem Computer hat Maria ein tolles Unixoid mit dem *lokalen* Benutzernamen ```maria``` installiert. Eine **Shell** (Bash!) sieht immer folgendermassen aus:
@@ -31,8 +31,8 @@ Um ihre Arbeit speditiv zu erledigen, benutzt Maria gerne Tastenkürzel. Tastenk
 Bezeichnung    | Bedeutung
 -------------- |-----------
 Name           | ```Maria Muster```
-HSR-Benutzer   | ```mmuster```
-E-Mail-Adresse | ```maria.muster@hsr.ch```
+OST-Benutzer   | ```maria.muster```
+E-Mail-Adresse | ```maria.muster@ost.ch```
 Passwort       | ```GeHeim007```
 Shell normal   | ```$```
 Shell root     | ```$#```
@@ -45,20 +45,20 @@ User lokal     | ```maria```
  URL      | Bedeutung    | Beispiele
  -------- |------------- | ----------
  `/SEITE`   | Chefseiten | Startseite, Vereinsstatuten etc.
- `/hsr/NAME` | Umgebung an der HSR | WLAN, Drucken
- `/app/NAME` | HSR-Programmkonfiguration | Thunderbird, Eclipse
+ `/hsr/NAME` | Umgebung an der OST | WLAN, Drucken
+ `/app/NAME` | OST-Programmkonfiguration | Thunderbird, Eclipse
 `/tipps/NAME` | Tipps & Tricks aus der Community | Github Student Developer Pack etc.
 
-### Dokumentationen zur Umgebung an der HSR
+### Dokumentationen zur Umgebung an der OST
 
 In diese Kategorie fallen grundsätzliche, programmunabhängige **technische Angaben**.
 
 Zudem wird jeweils die von uns empfohlene, **einfachste Lösung mit Ubuntu** von der Programmkonfiguration eingebunden.
 
 
-### HSR-Spezifische Programm- oder Systemkonfiguration
+### OST-Spezifische Programm- oder Systemkonfiguration
 
-Hier werden **HSR-Konfigurationen für bestimmte Programme** sowie Schritt-für-Schritt Anleitungen für Einsteiger hinterlegt.
+Hier werden **OST-Konfigurationen für bestimmte Programme** sowie Schritt-für-Schritt Anleitungen für Einsteiger hinterlegt.
 
 ### Weiteres
 

--- a/tipps/index.html
+++ b/tipps/index.html
@@ -5,7 +5,7 @@ title: Tipps &amp; Tricks
 
 <p>Im laufe des Studiums haben wir viele Tipps und Tricks entdeckt. Diese möchten wir dir nicht vorenthalten!</p>
 
-<p>Wenn du auch einen Tipp, ein Script, ein Tutorial, eine App oder sonst was hast - <a href="https://github.com/openhsr/www.openhsr.ch" alt="openHSR auf Github"> wir freuen uns über deinen Beitrag</a></p>
+<p>Wenn du auch einen Tipp, ein Script, ein Tutorial, eine App oder sonst was hast - <a href="https://github.com/openhsr/www.openhsr.ch" alt="openOST auf Github"> wir freuen uns über deinen Beitrag</a></p>
 
 
 {% for tag in site.tags %}


### PR DESCRIPTION
Changes the general wording on the pages to OST, the specific pages for WLAN, printing and more were not touched, as they require more than just a namechange.
It is therefore likely better to update these in individual PRs.
I left the content unchanged if I was unsure whether or not the old links were still valid, like for example the print mail as I have personally not used that.